### PR TITLE
Update SDKv5_Examples to v5.0.0

### DIFF
--- a/SDK v5 Examples/ios-sdk-app/Podfile
+++ b/SDK v5 Examples/ios-sdk-app/Podfile
@@ -4,5 +4,5 @@ use_frameworks!
 target 'ios-sdk-app' do
     project "ios-sdk-app"
     workspace 'ios-sdk-app'
-        pod 'MappedIn', '5.0.0-beta.7'
+        pod 'MappedIn', '5.0.0'
 end

--- a/SDK v5 Examples/ios-sdk-app/ios-sdk-app/ViewController+MPIMapViewDelegate.swift
+++ b/SDK v5 Examples/ios-sdk-app/ios-sdk-app/ViewController+MPIMapViewDelegate.swift
@@ -8,6 +8,11 @@ import Mappedin
 
 extension ViewController: MPIMapViewDelegate {
     
+    func onCameraChanged(cameraChange: Mappedin.MPICameraTransform) {
+        // Called when Camera tilt, zoom, rotation or position changes
+    }
+    
+    
     func onBlueDotPositionUpdate(update: MPIBlueDotPositionUpdate) {
         // Store a reference of the nearest node to use later when getting directions
         nearestNode = update.nearestNode
@@ -27,9 +32,8 @@ extension ViewController: MPIMapViewDelegate {
         selectedPolygon = polygon
         
         // Focus on polygon when clicked
-        //        mapView?.focusOn(focusOptions: MPIOptions.Focus(polygons: [polygon]))
-        mapView?.focusOn(focusOptions: MPIOptions.Focus(nodes: location.nodes))
-        
+        mapView?.cameraManager.focusOn(targets: MPIOptions.CameraTargets(nodes: location.nodes))
+                                       
         // Clear the present marker
         if let markerId = presentMarkerId {
             mapView?.removeMarker(id: markerId)
@@ -79,15 +83,14 @@ extension ViewController: MPIMapViewDelegate {
         self.onMapLoaded()
         
         // get default camera state
-        defaultRotation = mapView?.cameraControlsManager.rotation
-        defaultTilt = mapView?.cameraControlsManager.tilt
+        defaultRotation = mapView?.cameraManager.rotation
+        defaultTilt = mapView?.cameraManager.tilt
         
         // set camera state
-        mapView?.cameraControlsManager.setRotation(rotation: 180)
-        mapView?.cameraControlsManager.setTilt(tilt: 0)
+        mapView?.cameraManager.set(cameraTransform: MPIOptions.CameraConfiguration(tilt: 0, rotation: 180))
         
         // label all locations to be light on dark
-        mapView?.labelAllLocations(
+        mapView?.floatingLabelManager.labelAllLocations(
             options: MPIOptions.FloatingLabelAllLocations(
                 appearance: MPIOptions.FloatingLabelAppearance.darkOnLight
             )

--- a/SDK v5 Examples/ios-sdk-app/ios-sdk-app/ViewController.swift
+++ b/SDK v5 Examples/ios-sdk-app/ios-sdk-app/ViewController.swift
@@ -106,15 +106,12 @@ class ViewController: UIViewController {
               let tilt = defaultTilt
         else { return }
         
-        mapView?.cameraControlsManager.setRotation(rotation: rotation) { _, error in
+        mapView?.cameraManager.set(cameraTransform: MPIOptions.CameraConfiguration(tilt: tilt, rotation: rotation)){_, error in
             guard error == nil else { return }
             // access rotation here
-            print(self.mapView?.cameraControlsManager.rotation ?? "")
-        }
-        mapView?.cameraControlsManager.setTilt(tilt: tilt) { _, error in
-            guard error == nil else { return }
+            print(self.mapView?.cameraManager.rotation ?? "")
             // access tilt here
-            print(self.mapView?.cameraControlsManager.tilt ?? "")
+            print(self.mapView?.cameraManager.tilt ?? "")
         }
     }
     


### PR DESCRIPTION
Update from beta.7 to v5.0.0.

A couple changes were made to the SDK:
- `cameraControlsManager` is now merged with `cameraManager`
- `setRotation` and `setTilt` are entirely removed. Used `cameraManager.set` instead.
- `mapView?.labelAllLocations` updated to `mapView?.floatingLabelManager.labelAllLocations`