### PR TITLE
Release v6.0.0-alpha.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "Mappedin",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(name: "Mappedin", targets: ["Mappedin"])
+    ],
+    targets: [
+        .binaryTarget(
+            name: "Mappedin",
+            url: "https://github.com/MappedIn/ios/releases/download/6.0.0-alpha.0/Mappedin.xcframework.zip",
+            checksum: "ebb5689db2c7c90505577c558f73ddbd30e874e729bf09b665872279d27e059a"
+        )
+    ]
+)


### PR DESCRIPTION
## Mappedin iOS SDK v6.0.0-alpha.0

This is an automated release from Mappedin sdk-for-ios repository.

### Binary Distribution
- **Checksum:** `ebb5689db2c7c90505577c558f73ddbd30e874e729bf09b665872279d27e059a`

### Installation (after merge)
```swift
.package(url: "https://github.com/MappedIn/ios.git", from: "6.0.0-alpha.0")
```

---
*This PR was created automatically by the release workflow.*