### PR TITLE
Release v6.0.0-alpha.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "Mappedin",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(name: "Mappedin", targets: ["Mappedin"])
+    ],
+    targets: [
+        .binaryTarget(
+            name: "Mappedin",
+            url: "https://github.com/MappedIn/ios/releases/download/6.0.0-alpha.0/Mappedin.xcframework.zip",
+            checksum: "5aff2fddb90db91ac66551d02b8cc09c209a36ea1b325f2b58ddffbc2bb7c0f5"
+        )
+    ]
+)


### PR DESCRIPTION
## Mappedin iOS SDK v6.0.0-alpha.0

This is an automated release from Mappedin sdk-for-ios repository.

### Binary Distribution
- **Checksum:** `5aff2fddb90db91ac66551d02b8cc09c209a36ea1b325f2b58ddffbc2bb7c0f5`

### Installation (after merge)
```swift
.package(url: "https://github.com/MappedIn/ios.git", from: "6.0.0-alpha.0")
```

---
*This PR was created automatically by the release workflow.*