### PR TITLE
Release v6.0.0-alpha.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "Mappedin",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(name: "Mappedin", targets: ["Mappedin"])
+    ],
+    targets: [
+        .binaryTarget(
+            name: "Mappedin",
+            url: "https://github.com/MappedIn/ios/releases/download/6.0.0-alpha.0/Mappedin.xcframework.zip",
+            checksum: "aa9b4c8dfd7a062ce8230d7121415c359959383cfa154c617cf71ba921648055"
+        )
+    ]
+)


### PR DESCRIPTION
## Mappedin iOS SDK v6.0.0-alpha.0

This is an automated release from Mappedin sdk-for-ios repository.

### Binary Distribution
- **Checksum:** `aa9b4c8dfd7a062ce8230d7121415c359959383cfa154c617cf71ba921648055`

### Installation (after merge)
```swift
.package(url: "https://github.com/MappedIn/ios.git", from: "6.0.0-alpha.0")
```

---
*This PR was created automatically by the release workflow.*