### PR TITLE
Release v6.0.0-alpha.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "Mappedin",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .library(name: "Mappedin", targets: ["Mappedin"])
+    ],
+    targets: [
+        .binaryTarget(
+            name: "Mappedin",
+            url: "https://github.com/MappedIn/ios/releases/download/6.0.0-alpha.0/Mappedin.xcframework.zip",
+            checksum: "0f5f0f7a5d69cd8dba9c2f4e50ef3a2cfc6ca9ee2af24de475eeb2a24d48a97b"
+        )
+    ]
+)


### PR DESCRIPTION
## Mappedin iOS SDK v6.0.0-alpha.0

This is an automated release from Mappedin sdk-for-ios repository.

### Binary Distribution
- **Checksum:** `0f5f0f7a5d69cd8dba9c2f4e50ef3a2cfc6ca9ee2af24de475eeb2a24d48a97b`

### Installation (after merge)
```swift
.package(url: "https://github.com/MappedIn/ios.git", from: "6.0.0-alpha.0")
```

---
*This PR was created automatically by the release workflow.*