### PR TITLE
Release v6.0.0-alpha.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .binaryTarget(
             name: "Mappedin",
             url: "https://github.com/MappedIn/ios/releases/download/6.0.0-alpha.0/Mappedin.xcframework.zip",
-            checksum: "c9f4052584199c079d24a0a4c0f5097f94a5a0cdb8929b7d7c4f0bac7c8454ee"
+            checksum: "2178822e526ef3457fe718fb774f96731bf2d26804f9d818782e2e5f136b587e"
         )
     ]
 )


### PR DESCRIPTION
## Mappedin iOS SDK v6.0.0-alpha.0

This is an automated release from Mappedin sdk-for-ios repository.

### Binary Distribution
- **Checksum:** `2178822e526ef3457fe718fb774f96731bf2d26804f9d818782e2e5f136b587e`

### Installation (after merge)
```swift
.package(url: "https://github.com/MappedIn/ios.git", from: "6.0.0-alpha.0")
```

---
*This PR was created automatically by the release workflow.*