### PR TITLE
Release v6.0.0-alpha.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .binaryTarget(
             name: "Mappedin",
             url: "https://github.com/MappedIn/ios/releases/download/6.0.0-alpha.0/Mappedin.xcframework.zip",
-            checksum: "567769158536c499fc6582ae6d39777ba4f6e4fc1448c5ff98c25f776f93c07a"
+            checksum: "83154f039574745e3dde26534be68f06ffb934c2b0d4a4f9afe7a4d8b85fd3b7"
         )
     ]
 )


### PR DESCRIPTION
## Mappedin iOS SDK v6.0.0-alpha.0

This is an automated release from Mappedin sdk-for-ios repository.

### Binary Distribution
- **Checksum:** `83154f039574745e3dde26534be68f06ffb934c2b0d4a4f9afe7a4d8b85fd3b7`

### Installation (after merge)
```swift
.package(url: "https://github.com/MappedIn/ios.git", from: "6.0.0-alpha.0")
```

---
*This PR was created automatically by the release workflow.*