### PR TITLE
Release v6.0.0-alpha.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .binaryTarget(
             name: "Mappedin",
             url: "https://github.com/MappedIn/ios/releases/download/6.0.0-alpha.0/Mappedin.xcframework.zip",
-            checksum: "84eead7f418423302bd8ef2c6f9f3dc0a1650330d1128b622da5fc1106b91b20"
+            checksum: "4fb2190b53876c589290dfe62dd38c7bc7df2334eb64821f72c9ca1a8a92f386"
         )
     ]
 )


### PR DESCRIPTION
## Mappedin iOS SDK v6.0.0-alpha.0

This is an automated release from Mappedin sdk-for-ios repository.

### Binary Distribution
- **Checksum:** `4fb2190b53876c589290dfe62dd38c7bc7df2334eb64821f72c9ca1a8a92f386`

### Installation (after merge)
```swift
.package(url: "https://github.com/MappedIn/ios.git", from: "6.0.0-alpha.0")
```

---
*This PR was created automatically by the release workflow.*