### PR TITLE
Release v6.1.0-alpha.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Mappedin",
-            url: "https://github.com/MappedIn/ios/releases/download/6.0.0-alpha.0/Mappedin.xcframework.zip",
-            checksum: "4fb2190b53876c589290dfe62dd38c7bc7df2334eb64821f72c9ca1a8a92f386"
+            url: "https://github.com/MappedIn/ios/releases/download/6.1.0-alpha.1/Mappedin.xcframework.zip",
+            checksum: "e451614fe972d4d8fb77e9da470ff2ab36f030ffc9a0cf50bf9cc634d00d038a"
         )
     ]
 )


### PR DESCRIPTION
## Mappedin iOS SDK v6.1.0-alpha.1

This is an automated release from Mappedin sdk-for-ios repository.

### Binary Distribution
- **Checksum:** `e451614fe972d4d8fb77e9da470ff2ab36f030ffc9a0cf50bf9cc634d00d038a`

### Installation (after merge)
```swift
.package(url: "https://github.com/MappedIn/ios.git", from: "6.1.0-alpha.1")
```

---
*This PR was created automatically by the release workflow.*