### PR TITLE
Release v6.2.0-alpha.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Mappedin",
-            url: "https://github.com/MappedIn/ios/releases/download/6.1.0-alpha.1/Mappedin.xcframework.zip",
-            checksum: "e451614fe972d4d8fb77e9da470ff2ab36f030ffc9a0cf50bf9cc634d00d038a"
+            url: "https://github.com/MappedIn/ios/releases/download/6.2.0-alpha.1/Mappedin.xcframework.zip",
+            checksum: "6006bbe838d5445653152cf088bd7d19bdddd81d1ab144ef941064b0beb77942"
         )
     ]
 )


### PR DESCRIPTION
## Mappedin iOS SDK v6.2.0-alpha.1

This is an automated release from Mappedin sdk-for-ios repository.

### Binary Distribution
- **Checksum:** `6006bbe838d5445653152cf088bd7d19bdddd81d1ab144ef941064b0beb77942`

### Installation (after merge)
```swift
.package(url: "https://github.com/MappedIn/ios.git", from: "6.2.0-alpha.1")
```

---
*This PR was created automatically by the release workflow.*