### PR TITLE
Release v6.2.0-alpha.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Mappedin",
-            url: "https://github.com/MappedIn/ios/releases/download/6.2.0-alpha.1/Mappedin.xcframework.zip",
-            checksum: "6006bbe838d5445653152cf088bd7d19bdddd81d1ab144ef941064b0beb77942"
+            url: "https://github.com/MappedIn/ios/releases/download/6.2.0-alpha.2/Mappedin.xcframework.zip",
+            checksum: "95f160543a88bacd3e650c1a6e8845e6db53c6f73be966b8877610a08d22200b"
         )
     ]
 )


### PR DESCRIPTION
## Mappedin iOS SDK v6.2.0-alpha.2

This is an automated release from Mappedin sdk-for-ios repository.

### Binary Distribution
- **Checksum:** `95f160543a88bacd3e650c1a6e8845e6db53c6f73be966b8877610a08d22200b`

### Installation (after merge)
```swift
.package(url: "https://github.com/MappedIn/ios.git", from: "6.2.0-alpha.2")
```

---
*This PR was created automatically by the release workflow.*