### PR TITLE
Release v6.2.0-alpha.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Mappedin",
-            url: "https://github.com/MappedIn/ios/releases/download/6.2.0-alpha.2/Mappedin.xcframework.zip",
-            checksum: "95f160543a88bacd3e650c1a6e8845e6db53c6f73be966b8877610a08d22200b"
+            url: "https://github.com/MappedIn/ios/releases/download/6.2.0-alpha.3/Mappedin.xcframework.zip",
+            checksum: "5cd79cf87b3a315b3865288b98e853f3e4089f023e21393d0bd2bd32b3f400dd"
         )
     ]
 )


### PR DESCRIPTION
## Mappedin iOS SDK v6.2.0-alpha.3

This is an automated release from Mappedin sdk-for-ios repository.

### Binary Distribution
- **Checksum:** `5cd79cf87b3a315b3865288b98e853f3e4089f023e21393d0bd2bd32b3f400dd`

### Installation (after merge)
```swift
.package(url: "https://github.com/MappedIn/ios.git", from: "6.2.0-alpha.3")
```

---
*This PR was created automatically by the release workflow.*