### PR TITLE
Release v6.2.0-beta.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Mappedin",
-            url: "https://github.com/MappedIn/ios/releases/download/6.2.0-alpha.3/Mappedin.xcframework.zip",
-            checksum: "5cd79cf87b3a315b3865288b98e853f3e4089f023e21393d0bd2bd32b3f400dd"
+            url: "https://github.com/MappedIn/ios/releases/download/6.2.0-beta.0/Mappedin.xcframework.zip",
+            checksum: "592a2355df00116386742a61b9fa2df4acc919a6f20f6bdc6225d01b11f901e1"
         )
     ]
 )


### PR DESCRIPTION
## Mappedin iOS SDK v6.2.0-beta.0

This is an automated release from Mappedin sdk-for-ios repository.

### Binary Distribution
- **Checksum:** `592a2355df00116386742a61b9fa2df4acc919a6f20f6bdc6225d01b11f901e1`

### Installation (after merge)
```swift
.package(url: "https://github.com/MappedIn/ios.git", from: "6.2.0-beta.0")
```

---
*This PR was created automatically by the release workflow.*