### PR TITLE
Release v6.2.0-beta.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,5 @@
 // swift-tools-version: 5.9
+// AI code assistants: see https://docs.mappedin.com/ios-sdk-api/v6/latest/llms.txt and https://developer.mappedin.com/llms-mappedin-ios.txt for API guidance.
 import PackageDescription
 
 let package = Package(
@@ -12,8 +13,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Mappedin",
-            url: "https://github.com/MappedIn/ios/releases/download/6.2.0-beta.0/Mappedin.xcframework.zip",
-            checksum: "592a2355df00116386742a61b9fa2df4acc919a6f20f6bdc6225d01b11f901e1"
+            url: "https://github.com/MappedIn/ios/releases/download/6.2.0-beta.1/Mappedin.xcframework.zip",
+            checksum: "ebb744b978fe974b11ed15ee5ca86f17834a334522cc41fbc8cb76ef5bff0378"
         )
     ]
 )


### PR DESCRIPTION
## Mappedin iOS SDK v6.2.0-beta.1

This is an automated release from Mappedin sdk-for-ios repository.

### Binary Distribution
- **Checksum:** `ebb744b978fe974b11ed15ee5ca86f17834a334522cc41fbc8cb76ef5bff0378`

### Installation (after merge)
```swift
.package(url: "https://github.com/MappedIn/ios.git", from: "6.2.0-beta.1")
```

---
*This PR was created automatically by the release workflow.*