### PR TITLE
Release v6.2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Mappedin",
-            url: "https://github.com/MappedIn/ios/releases/download/6.2.0-beta.1/Mappedin.xcframework.zip",
-            checksum: "ebb744b978fe974b11ed15ee5ca86f17834a334522cc41fbc8cb76ef5bff0378"
+            url: "https://github.com/MappedIn/ios/releases/download/6.2.0/Mappedin.xcframework.zip",
+            checksum: "e87536911820c0a6f9d1e29c92a20dea833b9a5cb3014baaa13fa6841c07a41e"
         )
     ]
 )


### PR DESCRIPTION
## Mappedin iOS SDK v6.2.0

This is an automated release from Mappedin sdk-for-ios repository.

### Binary Distribution
- **Checksum:** `e87536911820c0a6f9d1e29c92a20dea833b9a5cb3014baaa13fa6841c07a41e`

### Installation (after merge)
```swift
.package(url: "https://github.com/MappedIn/ios.git", from: "6.2.0")
```

---
*This PR was created automatically by the release workflow.*