### PR TITLE
Release v6.4.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Mappedin",
-            url: "https://github.com/MappedIn/ios/releases/download/6.3.0/Mappedin.xcframework.zip",
-            checksum: "bf548ea94e16c819df8821121afdc61b97b446d19672539e55eea194742d597e"
+            url: "https://github.com/MappedIn/ios/releases/download/6.4.0/Mappedin.xcframework.zip",
+            checksum: "4fe24f3bbe35c8b5297aa4032b9db171659f2d3466e9a459b30a05284d53df85"
         )
     ]
 )


### PR DESCRIPTION
## Mappedin iOS SDK v6.4.0

This is an automated release from Mappedin sdk-for-ios repository.

### Binary Distribution
- **Checksum:** `4fe24f3bbe35c8b5297aa4032b9db171659f2d3466e9a459b30a05284d53df85`

### Installation (after merge)
```swift
.package(url: "https://github.com/MappedIn/ios.git", from: "6.4.0")
```

---
*This PR was created automatically by the release workflow.*