### PR TITLE
Release v6.5.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Mappedin",
-            url: "https://github.com/MappedIn/ios/releases/download/6.4.0/Mappedin.xcframework.zip",
-            checksum: "4fe24f3bbe35c8b5297aa4032b9db171659f2d3466e9a459b30a05284d53df85"
+            url: "https://github.com/MappedIn/ios/releases/download/6.5.0/Mappedin.xcframework.zip",
+            checksum: "bdb7a4b05b29b5866399eb94ac521ef961f9635933b0da93e85eb64c901c478f"
         )
     ]
 )


### PR DESCRIPTION
## Mappedin iOS SDK v6.5.0

This is an automated release from Mappedin sdk-for-ios repository.

### Binary Distribution
- **Checksum:** `bdb7a4b05b29b5866399eb94ac521ef961f9635933b0da93e85eb64c901c478f`

### Installation (after merge)
```swift
.package(url: "https://github.com/MappedIn/ios.git", from: "6.5.0")
```

---
*This PR was created automatically by the release workflow.*